### PR TITLE
Updated SUPPORTED.md with new configuration

### DIFF
--- a/SUPPORTED.md
+++ b/SUPPORTED.md
@@ -13,5 +13,6 @@
 | Ubuntu 17.10   | 4.13.0-32-generic      | none         | none        | 2:1.0.21-2     |                           |
 | Ubuntu 17.10   | 4.13.0-38-generic      | none         | none        | 2:1.0.21-2     | MSI GS63VR 7RF Stealth Pro|
 | eOS 0.4.1      | 4.13.0-38-generic      | none         | none        | 2:1.0.20-1     | MSI GE70 2PE Apache Pro   |
+| Ubuntu 18.04   | 4.15.0-20-generic      | none         | none        | 2:1.0.21-2     | MSI GS63VR 7RF Stealth Pro|
 
 [1]: https://wiki.ubuntu.com/Kernel/LTSEnablementStack#Ubuntu_16.04_LTS_-_Xenial_Xerus


### PR DESCRIPTION
Added MSI GS63VR 7RF Stealth Pro running Ubuntu 18.04 LTS with libusb 2:1.0.21-2. Kernel version 4.15.0-20-generic.