### PR TITLE
Updates some dependencies: msi-keyboard to 0.4.1, electron to 1.8.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,14 +11,14 @@
   "scripts": {
     "start": "npm run build:app:linux && electron ./dist/app",
     "start:windows": "npm run build:app:windows && electron ./dist/app",
-    "build:linux": "npm run build:app:linux && electron-packager ./dist/app/ --overwrite --out=dist --electron-version=1.7.9 --platform=linux --arch=x64 --app-bundle-id=com.stevelacy.msikeyboard --app-version=$npm_package_version && cd dist/ && tar -czvf ./msi-keyboard-gui-linux-${npm_package_version}.tar.gz msi-keyboard-gui-linux-x64/*",
-    "build:windows": "npm run build:app:windows && electron-packager ./dist/app/ --overwrite --out=dist --electron-version=1.7.9 --platform=win32 --arch=x64 --app-bundle-id=com.stevelacy.msikeyboard --app-version=%npm_package_version% && cd dist/",
-    "build:app:linux": "npm rebuild --runtime=electron --target=1.7.9 --disturl=https://atom.io/download/atom-shell --npm_config_build_from_source=true && babel src/ --out-dir ./dist/app/src/ && cp -t ./dist/app/src/ ./src/index.html ./src/index.css && cp -rt ./dist/app/ index.js package.json node_modules LICENSE",
-    "build:app:windows": "npm rebuild --runtime=electron --target=1.7.9 --disturl=https://atom.io/download/atom-shell --npm_config_build_from_source=true && babel src/ --out-dir .\\dist\\app\\src\\ && copy .\\src\\index.html .\\dist\\app\\src\\ && copy .\\src\\index.css .\\dist\\app\\src\\ && copy index.js .\\dist\\app\\ && copy package.json .\\dist\\app\\ && xcopy .\\node_modules .\\dist\\app\\node_modules\\ /e/i/h/y/a && copy LICENSE .\\dist\\app\\"
+    "build:linux": "npm run build:app:linux && electron-packager ./dist/app/ --overwrite --out=dist --electron-version=1.8.8 --platform=linux --arch=x64 --app-bundle-id=com.stevelacy.msikeyboard --app-version=$npm_package_version && cd dist/ && tar -czvf ./msi-keyboard-gui-linux-${npm_package_version}.tar.gz msi-keyboard-gui-linux-x64/*",
+    "build:windows": "npm run build:app:windows && electron-packager ./dist/app/ --overwrite --out=dist --electron-version=1.7.8 --platform=win32 --arch=x64 --app-bundle-id=com.stevelacy.msikeyboard --app-version=%npm_package_version% && cd dist/",
+    "build:app:linux": "npm rebuild --runtime=electron --target=1.8.8 --disturl=https://atom.io/download/atom-shell --npm_config_build_from_source=true && babel src/ --out-dir ./dist/app/src/ && cp -t ./dist/app/src/ ./src/index.html ./src/index.css && cp -rt ./dist/app/ index.js package.json node_modules LICENSE",
+    "build:app:windows": "npm rebuild --runtime=electron --target=1.8.8 --disturl=https://atom.io/download/atom-shell --npm_config_build_from_source=true && babel src/ --out-dir .\\dist\\app\\src\\ && copy .\\src\\index.html .\\dist\\app\\src\\ && copy .\\src\\index.css .\\dist\\app\\src\\ && copy index.js .\\dist\\app\\ && copy package.json .\\dist\\app\\ && xcopy .\\node_modules .\\dist\\app\\node_modules\\ /e/i/h/y/a && copy LICENSE .\\dist\\app\\"
   },
   "dependencies": {
     "electron-debug": "^1.1.0",
-    "msi-keyboard": "^0.3.1",
+    "msi-keyboard": "^0.4.1",
     "react": "^15.0.2",
     "classnames": "^2.2.5",
     "react-dom": "^15.0.2"
@@ -28,7 +28,7 @@
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.16.0",
     "babel-register": "^6.8.0",
-    "electron": "^1.7.9",
+    "electron": "^1.8.8",
     "electron-packager": "^8.4.0"
   },
   "engines": {


### PR DESCRIPTION
Updating the `msi-keyboard` version fixes #55 and updating the Electron version to 1.8.8 fixed the node module version mismatch problem for me: 
```
The module '/home/bart/leds/fix/msi-keyboard-gui/dist/app/node_modules/node-hid/build/Release/HID.node'
was compiled against a different Node.js version using
NODE_MODULE_VERSION 54. This version of Node.js requires
NODE_MODULE_VERSION 57. Please try re-compiling or re-installing
the module (for instance, using `npm rebuild` or `npm install`).
```

P.S. I'm using Node 8.11.4.