### PR TITLE
add Pop!_OS on MSI GP73 to supported list

### DIFF
--- a/SUPPORTED.md
+++ b/SUPPORTED.md
@@ -21,5 +21,6 @@
 | Ubuntu 18.04.1 | 4.15.0-39-generic      | 8.10.0       | 3.5.2       | none           | MSI GT70 2PE Dominator Pro |
 | Ubuntu 18.04.1 | 4.15.0-44-generic      | 10.15.0      | 6.4.1       | 2:1.0.21-2     | MSI GS63 7RE Stealth Pro   |
 | Ubuntu 18.04.5 | 4.15.0.135-generic     | 8.10.0       | 3.5.2       | 2:1.0.21-2     | MSI GE70 2PE Apache Pro    |
+| Pop!_OS 21.04  | 5.11.0-7620-generic    | 14.17.0      | 6.14.13     | 2:1.0.24-3     | MSI GP73 8RE Leopard       |
 
 [1]: https://wiki.ubuntu.com/Kernel/LTSEnablementStack#Ubuntu_16.04_LTS_-_Xenial_Xerus


### PR DESCRIPTION
also, just a quick note: I didn't know off-hand how to check my `libusb` version, and it took a bit of searching and trial and error to finally end up at `apt-cache policy libusb-1.0.0`..

if there is a more reliable, or perhaps "recommended" way to check this, perhaps it would be an idea to add a note to the `SUPPORTED.md` document?

either way, massive thanks for the time and effort that went into this.. 👍🏼 